### PR TITLE
Fix typo in part_3.md module

### DIFF
--- a/_modules/part_3.md
+++ b/_modules/part_3.md
@@ -12,7 +12,7 @@ Oct 3
 : [Condition Variables](#)
 
 Oct 4
-: **Tutorial 7**{: .label .label-green }
+: **Tutorial 6**{: .label .label-green }
 
 Oct 7
 : [Introduction to Semaphores](#)


### PR DESCRIPTION
There was an error, that "Tutorial 7" was repeated twice instead of the prior being "Tutorial 6", in the Calendar section.